### PR TITLE
Add Less v2 as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=0.4.2"
   },
   "dependencies": {
-    "less": "https://github.com/less/less.js.git#2_0_0",
+    "less": "git+https://github.com/less/less.js.git#2_0_0",
     "resolve": "~1.0.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
This is a Less plugin, so Less is required. Include it as a dependency.

Whitespace changes are a result of npm install --save. Also removed "autoprefixer" from keywords.
