### PR TITLE
Use `less` property in package.json if provided

### DIFF
--- a/lib/npm-file-manager.js
+++ b/lib/npm-file-manager.js
@@ -24,6 +24,11 @@ module.exports = function(less) {
             extensions: ['.less', '.css'],
             packageFilter: function packageFilter(info, pkgdir) {
                 // replace main
+                if (typeof info.less === 'string') {
+                    info.main = info.less;
+                    return info;
+                }
+
                 if (typeof info.style === 'string') {
                     info.main = info.style;
                     return info;

--- a/lib/npm-file-manager.js
+++ b/lib/npm-file-manager.js
@@ -23,11 +23,6 @@ module.exports = function(less) {
             basedir: currentDirectory,
             extensions: ['.less', '.css'],
             packageFilter: function packageFilter(info, pkgdir) {
-                // no style field, keep info unchanged
-                if (!info.style) {
-                    return info;
-                }
-
                 // replace main
                 if (typeof info.style === 'string') {
                     info.main = info.style;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     },
     "devDependencies": {
         "npm-import-plugin-test": "1.0.0",
-        "less": "~2.2.0"
+        "less": "~2.4.0"
     },
     "keywords": [
         "less plugins",


### PR DESCRIPTION
Among others, Bootstrap is using it for the root less stylesheet, and `style` for already compiled CSS file.

This allows one to use less variables in Bootstrap.

Beware that this is a backwards-incompatible change.