### PR TITLE
Support index.less when referencing a directory or module

### DIFF
--- a/lib/npm-file-manager.js
+++ b/lib/npm-file-manager.js
@@ -69,5 +69,13 @@ module.exports = function(less) {
         return FileManager.prototype.loadFileSync.call(this, filename, "", options, environment);
     };
 
+    NpmFileManager.prototype.tryAppendExtension = function(path, ext) {
+        return path;
+    };
+
+    NpmFileManager.prototype.tryAppendLessExtension = function(path) {
+        return path;
+    };
+
     return NpmFileManager;
 };

--- a/test/css/npm-import/test.css
+++ b/test/css/npm-import/test.css
@@ -7,3 +7,9 @@
 .test_deeper_file {
   color: black;
 }
+.test_index {
+  color: black;
+}
+.test_deeper_index {
+  color: black;
+}

--- a/test/less/npm-import/test.less
+++ b/test/less/npm-import/test.less
@@ -1,3 +1,5 @@
 @import "npm://npm-import-plugin-test/file";
 @import (less) "npm://npm-import-plugin-test/file.css";
 @import "npm://npm-import-plugin-test/deeper/file";
+@import "npm://npm-import-plugin-test";
+@import "npm://npm-import-plugin-test/deeper/";


### PR DESCRIPTION
The `extensions` option of resolve is effectively not used because less adds a file extension to the path before it calls `NpmFileManager.prototype.loadFile`. This means that for a line such as `@import "npm://mymodule"`, less will pass `@import "npm://mymodule.less"`. 

This patch fixes that by making sure less never adds the extension, instead the resolve module will take care of the extensions. This means that `@import "npm://mymodule"` will look for a `index.less` or `index.css` file in "mymodule".