### PR TITLE
Workaround for node-resolve bug on windows

### DIFF
--- a/lib/npm-file-manager.js
+++ b/lib/npm-file-manager.js
@@ -1,6 +1,7 @@
 var resolveNpmFile = require('resolve').sync,
     win32 = process.platform === 'win32',
-    PromiseConstructor = typeof Promise === 'undefined' ? require('promise') : Promise;
+    PromiseConstructor = typeof Promise === 'undefined' ? require('promise') : Promise,
+    path = require('path');
 
 module.exports = function(less) {
     var FileManager = less.FileManager;
@@ -24,6 +25,7 @@ module.exports = function(less) {
     NpmFileManager.prototype.resolve = function(filename, currentDirectory) {
         filename = filename.replace(this.options.prefix, "");
         currentDirectory = currentDirectory.replace(this.options.prefix, "");
+        currentDirectory = path.resolve(currentDirectory);
         return resolveNpmFile(filename, {
             basedir: currentDirectory,
             extensions: ['.less', '.css'],


### PR DESCRIPTION
See: https://github.com/substack/node-resolve/issues/78

Referencing a module does not work for me on windows because node-resolve tries to use `/D:\Users\joris_000\Documents\Projects\foo\lib\foo\node_modules`, that first slash messes it up.

If you use an absolute path for the basedir option, this issue does not occur