### PR TITLE
Update README.md for importing a css file with an import option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ In less file:
 @import "npm://packagename/path/to/file.less";
 ```
 
+or if importing a css file an [import option](http://lesscss.org/features/#import-options) is required:
+
+```
+@import (less) "npm://packagename/path/to/file.css";
+```
+
 css/less extensions not necessary
 
 Options:  


### PR DESCRIPTION
Added a second lessc usage example for when importing a css file directly from a npm dependency; e.g. in a gulp task. In this case a less import option is required to embed the css.