### PR TITLE
Add support for new option 'basedir' so you can set where npm modules are resolved.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,24 @@ css/less extensions not necessary
 
 Options:  
 prefix - default: npm://
+basedir - allow setting the basedir node modules should be resolved from.
 
 ## Command line usage
 
 ```
 lessc --npm-import file.less file.css
 lessc --npm-import="prefix=~" file.less file.css
+lessc --npm-import="basedir=/usr/local/path" file.less file.css
 ```
 
 ## Programmatic usage
 
 ```
 var NpmImportPlugin = require("less-plugin-npm-import"),
-    options = { plugins: [new NpmImportPlugin({prefix: '~'})] };
+    options = { plugins: [new NpmImportPlugin({
+      prefix: '~',
+      basedir: __dirname
+    })] };
 less.render(css, options)
     .then(...
 ```

--- a/lib/npm-file-manager.js
+++ b/lib/npm-file-manager.js
@@ -27,7 +27,8 @@ module.exports = function(less) {
         currentDirectory = currentDirectory.replace(this.options.prefix, "");
         currentDirectory = path.resolve(currentDirectory);
         return resolveNpmFile(filename, {
-            basedir: currentDirectory,
+            basedir: typeof this.options.basedir === 'string' ?
+              this.options.basedir : currentDirectory,
             extensions: ['.less', '.css'],
             packageFilter: function packageFilter(info, pkgdir) {
                 // no style field, keep info unchanged

--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -10,6 +10,9 @@ module.exports = function(options) {
                 case "prefix":
                     options.prefix = argSplit[1];
                     break;
+                case "basedir":
+                    options.basedir = argSplit[1];
+                    break;
                 default:
                     throw new Error("unrecognised npm-import option '" + argSplit[0] + "'");
             }

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -8,7 +8,9 @@ module.exports = {
         console.log("");
     },
     printOptions: function() {
-      console.log("we support the following options... 'prefix'");
+      console.log("we support the following options...");
+      console.log("'prefix'");
+      console.log("'basedir'");
     }
 
 };

--- a/test/index.js
+++ b/test/index.js
@@ -13,3 +13,7 @@ lessTester.runTestSet(
 lessTester.runTestSet(
     {strictMath: true, relativeUrls: true, silent: true, plugins: [new plugin({ prefix: 'npm://'})] },
     "npm-import/");
+
+lessTester.runTestSet(
+    {strictMath: true, relativeUrls: true, silent: true, plugins: [new plugin({ basedir: __dirname})] },
+    "npm-import/");


### PR DESCRIPTION
This adds a new option `basedir` so that you can configure from where a npm module is resolved from (using the [node-resolve API](https://github.com/substack/node-resolve)).

This is needed for my project where in my project I have a npm module (scaffold) which has its own npm module (theme). I use this plugin in my project to compile the scaffold code which uses the theme which uses normalize.css as a npm module. 

Basically my parent project is trying to compile my LESS but this plugin always looks for npm modules at the root when I want it to look in the context of a node_modules directory.

Sorry if that's confusing.

Let me know what I can do!
