### PR TITLE
Add missing arguments to loadFile and laodFileSync

### DIFF
--- a/lib/npm-file-manager.js
+++ b/lib/npm-file-manager.js
@@ -47,7 +47,7 @@ module.exports = function(less) {
         });
     };
 
-    NpmFileManager.prototype.loadFile = function(filename, currentDirectory, options, environment) {
+    NpmFileManager.prototype.loadFile = function(filename, currentDirectory, options, environment, callback) {
         try {
             filename = this.resolve(filename, currentDirectory);
         }
@@ -58,17 +58,17 @@ module.exports = function(less) {
                 }
             );
         }
-        return FileManager.prototype.loadFile.call(this, filename, "", options, environment);
+        return FileManager.prototype.loadFile.call(this, filename, "", options, environment, callback);
     };
 
-    NpmFileManager.prototype.loadFileSync = function(filename, currentDirectory, options, environment) {
+    NpmFileManager.prototype.loadFileSync = function(filename, currentDirectory, options, environment, encoding) {
         try {
             filename = this.resolve(filename, currentDirectory);
         }
         catch(e) {
             return { error: e };
         }
-        return FileManager.prototype.loadFileSync.call(this, filename, "", options, environment);
+        return FileManager.prototype.loadFileSync.call(this, filename, "", options, environment, encoding);
     };
 
     NpmFileManager.prototype.tryAppendExtension = function(path, ext) {


### PR DESCRIPTION
I am using `less.render` in synchronous mode (using the `syncImport` less option) to preprocess css module files using [css-modules-require-hook][]. However, when using this plugin, less synchronous mode stops working -- the callback passed to `less.render` is never called.

After some digging, I found that this is because less's `import-manager.js` calls `loadFile` with a `callback` argument [(see here)][1] and `file-manager.js` calls `loadFileSync` with an `encoding` argument [(see here)][2]. The FileManager implemented in this module does not forward these arguments along, causing the calls to fail.

This PR fixes this module when using `less.render` in synchronous mode by adding the missing arguments.

[css-modules-require-hook]: https://github.com/css-modules/css-modules-require-hook
[1]: https://github.com/less/less.js/blob/4a0026ebf6d4c783365d3701ac796c18dcc9d30f/lib/less/import-manager.js#L119
[2]: https://github.com/less/less.js/blob/4a0026ebf6d4c783365d3701ac796c18dcc9d30f/lib/less-node/file-manager.js#L32